### PR TITLE
[swdb]: manage forward declarations

### DIFF
--- a/libdnf/swdb/item_comps_environment.hpp
+++ b/libdnf/swdb/item_comps_environment.hpp
@@ -24,13 +24,12 @@
 #include <memory>
 #include <vector>
 
+class CompsEnvironmentItem;
+class CompsEnvironmentGroup;
+
 #include "item.hpp"
 #include "item_comps_group.hpp"
 #include "transactionitem.hpp"
-
-class CompsEnvironmentGroup;
-enum class CompsPackageType;
-class TransactionItem;
 
 class CompsEnvironmentItem : public Item {
 public:

--- a/libdnf/swdb/item_comps_group.hpp
+++ b/libdnf/swdb/item_comps_group.hpp
@@ -24,11 +24,6 @@
 #include <memory>
 #include <vector>
 
-#include "item.hpp"
-#include "transactionitem.hpp"
-
-class TransactionItem;
-
 enum class CompsPackageType : int {
     MANDATORY = 0,
     DEFAULT = 1,
@@ -36,10 +31,11 @@ enum class CompsPackageType : int {
     CONDITIONAL = 3,
 };
 
-class Item;
 class CompsGroupItem;
 class CompsGroupPackage;
-class TransactionItem;
+
+#include "item.hpp"
+#include "transactionitem.hpp"
 
 class CompsGroupItem : public Item {
 public:

--- a/libdnf/swdb/item_rpm.hpp
+++ b/libdnf/swdb/item_rpm.hpp
@@ -24,12 +24,11 @@
 #include <memory>
 #include <vector>
 
+class RPMItem;
+
 #include "item.hpp"
 #include "swdb_types.hpp"
 #include "transactionitem.hpp"
-
-class Item;
-class TransactionItem;
 
 class RPMItem : public Item {
 public:

--- a/libdnf/swdb/transaction.hpp
+++ b/libdnf/swdb/transaction.hpp
@@ -27,13 +27,10 @@
 
 #include "../utils/sqlite3/sqlite3.hpp"
 
+class Transaction;
+
 #include "item.hpp"
 #include "transactionitem.hpp"
-
-class TransactionItem;
-class RPMItem;
-enum class TransactionItemAction;
-enum class TransactionItemReason;
 
 class Transaction {
 public:

--- a/libdnf/swdb/transactionitem.hpp
+++ b/libdnf/swdb/transactionitem.hpp
@@ -26,6 +26,8 @@
 
 #include "../utils/sqlite3/sqlite3.hpp"
 
+class TransactionItem;
+
 #include "item.hpp"
 #include "item_comps_environment.hpp"
 #include "item_comps_group.hpp"
@@ -33,12 +35,6 @@
 #include "repo.hpp"
 #include "swdb_types.hpp"
 #include "transaction.hpp"
-
-class Item;
-class CompsEnvironmentItem;
-class CompsGroupItem;
-class RPMItem;
-class Transaction;
 
 class TransactionItem {
 public:


### PR DESCRIPTION
Forward declaration of a single class multiple times across the headers
doesn't seem to me like a good practice.

A forward declaration should be done only in the header, which contains
the class definition, above the other imports (to avoid circular
dependencies).